### PR TITLE
fix columns amount for mobile

### DIFF
--- a/src/rootStyles.ts
+++ b/src/rootStyles.ts
@@ -66,8 +66,8 @@ export const rootStyles = css`
 
     --ts-copy: normal normal var(--ts-font-weight-regular) normal
       var(--font-size-md) / var(--line-height-md) var(--ts-font-family);
-      
-      --column-count: 3;
+
+    --column-count: 3;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -78,8 +78,17 @@ export const rootStyles = css`
   }
 
   /*
-    mobile specific
+  tablet specific
   */
+  @media (max-width: 1200px) {
+    :host {
+      --column-count: 2;
+    }
+  }
+
+  /*
+      mobile specific
+    */
   @media (max-width: 600px) {
     :host {
       --font-size-3xl: 2.75rem;
@@ -94,15 +103,6 @@ export const rootStyles = css`
       --line-height-lg: 1.5rem;
       --line-height-md: 1.5rem;
       --column-count: 1;
-    }
-  }
-  
-  /*
-    tablet specific
-  */
-  @media(max-width: 1200px) {
-    :host {
-        --column-count: 2;
     }
   }
 


### PR DESCRIPTION
The specificity was incorrectly for the mobile CSS, so that there were still 2 columns on mobile, instead of one.